### PR TITLE
Change mapped value of Level::Trace from 0 to 5

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@
 //! `::` occurrences with `.` (both form hierarchy in their respective language).
 //!
 //! Log levels are mapped to the same-named ones. The [`Trace`][Level::Trace] doesn't exist on the
-//! Python side, but is mapped to a level with value 0.
+//! Python side, but is mapped to a level with value 5.
 
 use std::cmp;
 use std::collections::HashMap;
@@ -478,7 +478,7 @@ fn map_level(level: Level) -> usize {
         Level::Warn => 30,
         Level::Info => 20,
         Level::Debug => 10,
-        Level::Trace => 0,
+        Level::Trace => 5,
     }
 }
 


### PR DESCRIPTION
The problem I have right now is that I cannot find any way to get Trace logs in my Python code using pyo3-log.

Looks like value 0 has a special meaning in Python logging. To give an example:

import logging
logging.basicConfig(level=logging.NOTSET)
logging.log(1, "My message level 1") # this gets logged
logging.log(0, "My message level 0") # this does not get logged

logger = logging.getLogger(__name__)
print(logger.isEnabledFor(logging.NOTSET)) # this returns false

Since pyo3-log uses isEnabledFor to check if it should log, the Trace logs are not logged even if Python logging is set to level 0.

The fix for this could be to change the mapped value of Trace to any number from 1 to 9. This pull request changes it to 5.