### PR TITLE
Update pyo3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,9 @@ license = "Apache-2.0/MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arc-swap = "~1"
-# It's OK to ask for std on log, because pyo3 needs it too.
+arc-swap = "~1" # It's OK to ask for std on log, because pyo3 needs it too.
 log = { version = "~0.4", default-features = false, features = ["std"] }
-pyo3 = { version = "~0.15", default-features = false, features = ["macros"] }
+pyo3 = { version = "~0.16", default-features = false, features = ["macros"] }
 
 [dev-dependencies]
-pyo3 = { version = "0.15", features = ["auto-initialize"] }
+pyo3 = { version = "0.16", features = ["auto-initialize"] }


### PR DESCRIPTION
This PR updates PyO3 to 0.16. It does not bump versio numbers or anything like that, because i was not sure how you want to handle this.