### PR TITLE
Make the pyo3 dependency accept older versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,6 +54,40 @@ jobs:
       - name: Build & test
         run: cargo test --all-features
 
+  test-minimal-versions:
+    name: Build with the minimal supported versions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          # MSRV as set in Cargo.toml
+          toolchain: 1.48.0
+          default: true
+          profile: minimal
+
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.7"
+          architecture: x64
+
+      - name: Restore cache
+        uses: Swatinem/rust-cache@v1
+
+      - name: Install the minimal versions of dependencies
+        env:
+          # `-Z minimal-versions` is unstable, so we set 
+          # `RUSTC_BOOTSTRAP=1` to be able to use it on stable
+          RUSTC_BOOTSTRAP: "1"
+        run: cargo update -Z minimal-versions
+
+      - name: Build & test
+        run: cargo test --all-features
+
   rustfmt:
     name: Check formatting
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["pyo3", "python", "logging"]
 categories = ["development-tools::debugging"]
 edition = "2018"
 license = "Apache-2.0/MIT"
+rust-version = "1.48.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -17,7 +18,7 @@ license = "Apache-2.0/MIT"
 arc-swap = "~1"
 # It's OK to ask for std on log, because pyo3 needs it too.
 log = { version = "~0.4", default-features = false, features = ["std"] }
-pyo3 = { version = "~0.18", default-features = false, features = ["macros"] }
+pyo3 = { version = ">=0.14, <0.19", default-features = false, features = ["macros"] }
 
 [dev-dependencies]
-pyo3 = { version = "0.18", features = ["auto-initialize"] }
+pyo3 = { version = ">=0.14, <0.19", features = ["auto-initialize"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,12 @@ rust-version = "1.48.0"
 [dependencies]
 arc-swap = "~1"
 # It's OK to ask for std on log, because pyo3 needs it too.
-log = { version = "~0.4", default-features = false, features = ["std"] }
-pyo3 = { version = ">=0.14, <0.19", default-features = false, features = ["macros"] }
+log = { version = "~0.4.4", default-features = false, features = ["std"] }
+pyo3 = { version = ">=0.14, <0.19", default-features = false }
 
 [dev-dependencies]
-pyo3 = { version = ">=0.14, <0.19", features = ["auto-initialize"] }
+pyo3 = { version = ">=0.14, <0.19", default-features = false, features = ["auto-initialize", "macros"] }
+
+# `pyo3-macros` is lying about the minimal version for its `syn` dependency.
+# Because we're testing with `-Zminimal-versions`, we need to explicitly set it here.
+syn = "~1.0.13"


### PR DESCRIPTION
This loosens the version requirements for the `pyo3` dependency to allow older versions.
It also adds a CI job to test with the oldest supported version of all dependencies, to check that we don't accidentally break compatibility with older versions.

I had to tweak the minimal versions of both `log` and `syn` (an indirect dependency) so that building with `-Zminimal-versions` works

I think it should allow making patch releases instead of minor versions in the future whenever there is a pyo3 bump, since upgrading wouldn't be a breaking change anymore?