### PR TITLE
Bump pyo3 minimal version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ rust-version = "1.48.0"
 arc-swap = "~1"
 # It's OK to ask for std on log, because pyo3 needs it too.
 log = { version = "~0.4.4", default-features = false, features = ["std"] }
-pyo3 = { version = ">=0.14, <0.21", default-features = false }
+pyo3 = { version = ">=0.15, <0.21", default-features = false }
 
 [dev-dependencies]
-pyo3 = { version = ">=0.14, <0.21", default-features = false, features = ["auto-initialize", "macros"] }
+pyo3 = { version = ">=0.15, <0.21", default-features = false, features = ["auto-initialize", "macros"] }
 
 # `pyo3-macros` is lying about the minimal version for its `syn` dependency.
 # Because we're testing with `-Zminimal-versions`, we need to explicitly set it here.


### PR DESCRIPTION
Increases the PyO3 minimal version to 0.15 as I think it might help avoid an occasional bug we see reported in the PyO3 repo, see https://github.com/PyO3/pyo3/issues/3509#issuecomment-1762329054

Potentially we could go higher than 0.15 depending on what compatibility you want to upkeep here.