### PR TITLE
Update deprecated SPDX license expression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 keywords = ["pyo3", "python", "logging"]
 categories = ["development-tools::debugging"]
 edition = "2018"
-license = "Apache-2.0/MIT"
+license = "Apache-2.0 OR MIT"
 rust-version = "1.48.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
The use of slashes in the Cargo.toml license field was deprecated by crates.io in favor of the “OR” keyword, so it is a valid SPDX license expression. Reference: https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields