### PR TITLE
Update to pyo3 0.21

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -63,7 +63,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           # MSRV as set in Cargo.toml
-          toolchain: 1.48.0
+          toolchain: 1.56.0
           default: true
           profile: minimal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.10.0
+
+* Update to pyo3 0.21.
+
 # 0.9.0
 
 * Bump lowest allowed version of pyo3 to 0.15 ‒ this prevents linking multiple

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["pyo3", "python", "logging"]
 categories = ["development-tools::debugging"]
 edition = "2018"
 license = "Apache-2.0 OR MIT"
-rust-version = "1.48.0"
+rust-version = "1.56.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -18,10 +18,10 @@ rust-version = "1.48.0"
 arc-swap = "~1"
 # It's OK to ask for std on log, because pyo3 needs it too.
 log = { version = "~0.4.4", default-features = false, features = ["std"] }
-pyo3 = { version = ">=0.15, <0.21", default-features = false }
+pyo3 = { version = ">=0.21, <0.22", default-features = false }
 
 [dev-dependencies]
-pyo3 = { version = ">=0.15, <0.21", default-features = false, features = ["auto-initialize", "macros"] }
+pyo3 = { version = ">=0.21, <0.22", default-features = false, features = ["auto-initialize", "macros"] }
 
 # `pyo3-macros` is lying about the minimal version for its `syn` dependency.
 # Because we're testing with `-Zminimal-versions`, we need to explicitly set it here.


### PR DESCRIPTION
This also makes the lowest supported version to 0.21 to migrate to the new `Bound` API.

Closes #48