### PR TITLE
Update pyo3 to 0.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.11.0
+
+* Update to pyo3 0.22.
+* `Logger` not longer implements `Clone`
+
 # 0.10.0
 
 * Update to pyo3 0.21.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyo3-log"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Michal 'vorner' Vaner <vorner@vorner.cz>"]
 description = "Logging bridge from pyo3 native extension to python"
 documentation = "https://docs.rs/pyo3-log"
@@ -18,10 +18,10 @@ rust-version = "1.56.0"
 arc-swap = "~1"
 # It's OK to ask for std on log, because pyo3 needs it too.
 log = { version = "~0.4.4", default-features = false, features = ["std"] }
-pyo3 = { version = ">=0.21, <0.22", default-features = false }
+pyo3 = { version = ">=0.21, <0.23", default-features = false }
 
 [dev-dependencies]
-pyo3 = { version = ">=0.21, <0.22", default-features = false, features = ["auto-initialize", "macros"] }
+pyo3 = { version = ">=0.21, <0.23", default-features = false, features = ["auto-initialize", "macros"] }
 
 # `pyo3-macros` is lying about the minimal version for its `syn` dependency.
 # Because we're testing with `-Zminimal-versions`, we need to explicitly set it here.


### PR DESCRIPTION
This removes the `Clone` impl from `Py<T>` which we can work around by keeping the GIL a bit longer in `log`. I believe that this has little to no implication (or maybe a positive one actually due to the switch to `clone_ref`).

However, this means that we have to remove `Clone` impl from `Logger`.

All of this is still compatible with `0.21` but still a breaking change.