### PR TITLE
Bump pyo3 to 0.22

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ rust-version = "1.56.0"
 arc-swap = "~1"
 # It's OK to ask for std on log, because pyo3 needs it too.
 log = { version = "~0.4.4", default-features = false, features = ["std"] }
-pyo3 = { version = ">=0.21, <0.22", default-features = false }
+pyo3 = { version = ">=0.22, <0.23", default-features = false, features = ["py-clone"] }
 
 [dev-dependencies]
-pyo3 = { version = ">=0.21, <0.22", default-features = false, features = ["auto-initialize", "macros"] }
+pyo3 = { version = ">=0.22, <0.23", default-features = false, features = ["auto-initialize", "macros"] }
 
 # `pyo3-macros` is lying about the minimal version for its `syn` dependency.
 # Because we're testing with `-Zminimal-versions`, we need to explicitly set it here.


### PR DESCRIPTION
For the moment, enable the py-clone feature which is necessary to allow Clone for PyObject. See https://pyo3.rs/main/migration#pyclone-is-now-gated-behind-the-py-clone-feature