### PR TITLE
feat: allow PyO3 0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ rust-version = "1.56.0"
 arc-swap = "~1"
 # It's OK to ask for std on log, because pyo3 needs it too.
 log = { version = "~0.4.4", default-features = false, features = ["std"] }
-pyo3 = { version = ">=0.21, <0.23", default-features = false }
+pyo3 = { version = ">=0.21, <0.24", default-features = false }
 
 [dev-dependencies]
-pyo3 = { version = ">=0.21, <0.23", default-features = false, features = ["auto-initialize", "macros"] }
+pyo3 = { version = ">=0.21, <0.24", default-features = false, features = ["auto-initialize", "macros"] }
 
 # `pyo3-macros` is lying about the minimal version for its `syn` dependency.
 # Because we're testing with `-Zminimal-versions`, we need to explicitly set it here.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,6 +303,8 @@ impl Logger {
     ///
     /// It defaults to having a filter for [`Debug`][LevelFilter::Debug].
     pub fn new(py: Python<'_>, caching: Caching) -> PyResult<Self> {
+        // `import` is only available in >=0.23.
+        #[allow(deprecated)]
         let logging = py.import_bound("logging")?;
         Ok(Self {
             top_filter: LevelFilter::Debug,
@@ -439,6 +441,8 @@ impl Logger {
                     record.file(),
                     record.line().unwrap_or_default(),
                     msg,
+                    // `empty` is only available in >=0.23.
+                    #[allow(deprecated)]
                     PyTuple::empty_bound(py), // args
                     &none,                    // exc_info
                 ),


### PR DESCRIPTION
Migration guide: https://pyo3.rs/v0.23.0/migration.html#from-022-to-023

`*_bound` methods [have been deprecated](https://pyo3.rs/v0.23.0/migration.html#gil-refs-feature-removed), so to continue supporting 0.21 and 0.22, this PR silences the deprecation. If completely dropping support for 0.21 and 0.22 is preferable, see #56.