### PR TITLE
feat: require `pyo3>=0.23`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ rust-version = "1.56.0"
 arc-swap = "~1"
 # It's OK to ask for std on log, because pyo3 needs it too.
 log = { version = "~0.4.4", default-features = false, features = ["std"] }
-pyo3 = { version = ">=0.21, <0.23", default-features = false }
+pyo3 = { version = ">=0.23, <0.24", default-features = false }
 
 [dev-dependencies]
-pyo3 = { version = ">=0.21, <0.23", default-features = false, features = ["auto-initialize", "macros"] }
+pyo3 = { version = ">=0.23, <0.24", default-features = false, features = ["auto-initialize", "macros"] }
 
 # `pyo3-macros` is lying about the minimal version for its `syn` dependency.
 # Because we're testing with `-Zminimal-versions`, we need to explicitly set it here.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -440,7 +440,7 @@ impl Logger {
                     record.line().unwrap_or_default(),
                     msg,
                     PyTuple::empty(py), // args
-                    &none,                    // exc_info
+                    &none,              // exc_info
                 ),
             )?;
             logger.call_method1("handle", (record,))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,7 +303,7 @@ impl Logger {
     ///
     /// It defaults to having a filter for [`Debug`][LevelFilter::Debug].
     pub fn new(py: Python<'_>, caching: Caching) -> PyResult<Self> {
-        let logging = py.import_bound("logging")?;
+        let logging = py.import("logging")?;
         Ok(Self {
             top_filter: LevelFilter::Debug,
             filters: HashMap::new(),
@@ -439,7 +439,7 @@ impl Logger {
                     record.file(),
                     record.line().unwrap_or_default(),
                     msg,
-                    PyTuple::empty_bound(py), // args
+                    PyTuple::empty(py), // args
                     &none,                    // exc_info
                 ),
             )?;


### PR DESCRIPTION
Migration guide: https://pyo3.rs/v0.23.0/migration.html#from-022-to-023

Alternative to #55 that completely drops support for 0.21 and 0.22 and move away from the deprecated methods.