### PR TITLE
Stop swallowing exceptions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -516,6 +516,8 @@ impl Log for Logger {
 
         if self.enabled_inner(record.metadata(), &cache) {
             Python::with_gil(|py| {
+                // If an exception were triggered before this attempt to log, 
+                // store it to the side for now and restore it afterwards.
                 let maybe_existing_exception = PyErr::take(py);
                 match self.log_inner(py, record, &cache) {
 
@@ -525,7 +527,8 @@ impl Log for Logger {
                         Caching::Loggers => LevelFilter::max(),
                         Caching::LoggersAndLevels => extract_max_level(logger.bind(py))
                             .unwrap_or_else(|e| {
-                                e.print(py);
+                                // See detailed NOTE below
+                                e.restore(py);
                                 LevelFilter::max()
                             }),
                     };
@@ -535,13 +538,16 @@ impl Log for Logger {
                 }
                 Ok(None) => (),
                 Err(e) => {
-                    e.print(py);
+                    // NOTE: If an exception was triggered _during_ logging, restore it as current Python exception.
+                    // We have to use PyErr::restore because we cannot return a PyResult from the Log trait's log method.
                     e.restore(py);
                 },
             };
-
-            if let Some(old_exception) = maybe_existing_exception {
-                old_exception.restore(py);
+            
+            // If there was a prior exception, restore it now
+            // This ensures that the earliest thrown exception will be the one that's visible to the caller.
+            if let Some(e) = maybe_existing_exception {
+                e.restore(py);
             }
         })
         }


### PR DESCRIPTION
Fixes #57 

This change ensure that rather calling `PyErr.print()` which prints the exception and then forgets about it, we call `PyErr.restore()` which restores it as 'current' exception.

If the calling Rust code:
- Returns a `()`, this will now trigger the same exception once we reach Python
- Uses `PyErr::take` to check for a current exception, it will fetch the exception and is able to manipulate it and turn it into a `PyResult` in whichever way it sees fit.
- Doesn't use `PyErr::take` to defuse the exception and returns something other than `()` itself, then Python will turn the originally thrown exception into a `SystemError`  with the message `SystemError: <method 'example' of 'builtins.YourCustomClass' objects> returned a result with an exception set`. The original exception is included as cause of this exception.