### PR TITLE
Add support for kv feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,14 +14,20 @@ rust-version = "1.74"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+kv = ["log/kv"]
+
 [dependencies]
 arc-swap = "~1"
 # It's OK to ask for std on log, because pyo3 needs it too.
-log = { version = "~0.4.4", default-features = false, features = ["std"] }
+log = { version = "~0.4.21", default-features = false, features = ["std"] }
 pyo3 = { version = "0.26", default-features = false }
 
 [dev-dependencies]
-pyo3 = { version = "0.26", default-features = false, features = ["auto-initialize", "macros"] }
+pyo3 = { version = "0.26", default-features = false, features = [
+    "auto-initialize",
+    "macros",
+] }
 
 # `pyo3-macros` is lying about the minimal version for its `syn` dependency.
 # Because we're testing with `-Zminimal-versions`, we need to explicitly set it here.

--- a/examples/hello_world/Cargo.lock
+++ b/examples/hello_world/Cargo.lock
@@ -15,12 +15,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,12 +43,9 @@ checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "memoffset"

--- a/examples/hello_world/Cargo.toml
+++ b/examples/hello_world/Cargo.toml
@@ -11,6 +11,6 @@ name = "hello_world"
 crate-type = ["cdylib"]
 
 [dependencies]
-log = "~0.4"
+log = { version = "~0.4", features = ["kv"] }
 pyo3 = { version = "~0.26", features = ["extension-module"] }
-pyo3-log = { path = "../.." }
+pyo3-log = { path = "../..", features = ["kv"] }

--- a/examples/hello_world/hw.py
+++ b/examples/hello_world/hw.py
@@ -3,8 +3,24 @@
 import logging
 import hello_world
 
-FORMAT = '%(levelname)s %(name)s %(asctime)-15s %(filename)s:%(lineno)d %(message)s'
-logging.basicConfig(format=FORMAT)
-logging.getLogger().setLevel(logging.INFO)
-logging.info("Test 1")
+
+class ExtraInfoFormatter(logging.Formatter):
+    def format(self, record):
+        record_dict = record.__dict__.copy()
+        standard_keys = logging.makeLogRecord({}).__dict__.keys()
+        extras = {k: v for k, v in record_dict.items()
+                  if k not in standard_keys}
+        extras_string = f" {extras}" if extras else ""
+        formatted_message = super().format(record)
+        return f"{formatted_message}{extras_string}"
+
+
+logger = logging.getLogger('hello_world')
+handler = logging.StreamHandler()
+handler.setFormatter(ExtraInfoFormatter("%(levelname)s:%(message)s"))
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
+logger.info("Hello, world!", extra={"foo": 42, "bar": "baz"})
+
 hello_world.log_hello()

--- a/examples/hello_world/src/lib.rs
+++ b/examples/hello_world/src/lib.rs
@@ -1,4 +1,4 @@
-use log::{debug, trace, info};
+use log::{debug, info, trace};
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
 use pyo3_log::{Caching, Logger};
@@ -10,12 +10,12 @@ fn log_hello() {
     debug!("Stuff");
     info!("Hello {}", "world");
     info!("Hello 2{}", "world");
+    info!(test = 5; "Hello world with KV");
 }
 
 #[pymodule]
 fn hello_world(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
-    let _ = Logger::new(py, Caching::LoggersAndLevels)?
-        .install();
+    let _ = Logger::new(py, Caching::LoggersAndLevels)?.install();
 
     m.add_wrapped(wrap_pyfunction!(log_hello))?;
 


### PR DESCRIPTION
Write structured data in `extra` argument and closes #68 .

The values are serialized to string, but in principle they could be converted to Python native types or perhaps to json with an additional `pyo3-log` feature.

