### PR TITLE
Bump pyo3 to 0.28

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,10 @@ kv = ["log/kv"]
 arc-swap = "~1"
 # It's OK to ask for std on log, because pyo3 needs it too.
 log = { version = "~0.4.21", default-features = false, features = ["std"] }
-pyo3 = { version = ">=0.26,<0.28", default-features = false }
+pyo3 = { version = ">=0.26,<0.29", default-features = false }
 
 [dev-dependencies]
-pyo3 = { version = ">=0.26,<0.28", default-features = false, features = [
+pyo3 = { version = ">=0.26,<0.29", default-features = false, features = [
     "auto-initialize",
     "macros",
 ] }


### PR DESCRIPTION
pyo3 0.28 has been released, see
https://github.com/PyO3/pyo3/releases/tag/v0.28.0

Repo builds and tests are passing locally.